### PR TITLE
iconvの新しいバージョンではUTF8 MACが無いのと、必用なさそうなので変換を削除

### DIFF
--- a/PasswordPaster/viewer.sh
+++ b/PasswordPaster/viewer.sh
@@ -107,7 +107,7 @@ keepass2alfred(){
             folder="$pfolder"
             pfolder="${folder%/*/}/"
         fi
-    done < "$xmlpath" | iconv -f UTF8 -t UTF8-MAC > "$filterxml"
+    done < "$xmlpath" > "$filterxml"
 
     echo "KeePass → Alfred"
 }


### PR DESCRIPTION
UTF8 MACは新しいiconvの変換リストに出てこないようです。

特に必用が無さそうな変換なので、削除致します。