### PR TITLE
GeoLite2-Cityデータベースの更新方法が変わったので変更

### DIFF
--- a/GeoIP2/README.md
+++ b/GeoIP2/README.md
@@ -11,6 +11,9 @@ Alfred を使用して、IPアドレスのカントリコードを簡単に引�
     - [GeoIP2.alfredworkflow のダウンロード](https://github.com/harasou/alfred-workflows/blob/master/alfredworkflow/GeoIP2.alfredworkflow?raw=true)
 
 1. MaxMind からデータベースのダウンロード
+	 - Workflowsを開き、GeoIP2で、geoip(keyword)の /bin/bash(Run script)を開く。
+	 - YOUR_LICENSE_KEY に自身のライセンスキーを入力する。<br>
+	   ※(ライセンスキーはmaxmindにアカウントを発行後、取得する: https://dev.maxmind.com/geoip/geoip2/geolite2/)
     - Alfred で `geoip` と入力し、`geoip download` を選択＆決定するとダウンロードが開始され、ダウンロードが完了すると通知がくる。
     - ![geoip_download](img/geoip_download.png)
 

--- a/GeoIP2/info.plist
+++ b/GeoIP2/info.plist
@@ -229,8 +229,6 @@
 				<key>script</key>
 				<string>#!/bin/bash
 
-#!/bin/bash
-
 LicenseKey=YOUR_LICENSE_KEY
 GL2CITY="GeoLite2-City"
 GeoURL="https://download.maxmind.com/app/geoip_download"
@@ -240,16 +238,16 @@ cd mmdb
 
 SHA256=$(curl -s "${GeoURL}?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz.sha256" | awk '{print $1}')
 
-if [ -f ${GL2CITY}.tar.gz -a "$SHA256" == "$(sha256sum ${GL2CITY}.tar.gz | awk '{print $1}')" ] ; then
+if [ -f ${GL2CITY}.tar.gz -a "$SHA256" == "$(shasum -a 256 ${GL2CITY}.tar.gz | awk '{print $1}')" ] ; then
     echo "データベースは最新でした"
     exit 0
 fi
 
 wget "$GeoURL?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz" -O ${GL2CITY}.tmp.tar.gz
 
-SHA256=$(sha256sum ${GL2CITY}.tar.gz | awk '{print $1}')
+SHA256=$(shasum -a 256 ${GL2CITY}.tar.gz | awk '{print $1}')
 
-if [ "$SHA256" == "$(sha256sum ${GL2CITY}.tmp.tar.gz | awk '{print $1}')" ] ; then
+if [ "$SHA256" == "$(shasum -a 256 ${GL2CITY}.tmp.tar.gz | awk '{print $1}')" ] ; then
     cp -p ${GL2CITY}.tmp.tar.gz ${GL2CITY}.tar.gz
     tar zxf ${GL2CITY}.tar.gz
     mv GeoLite2-City_*/${GL2CITY}.mmdb ${GL2CITY}.mmdb

--- a/GeoIP2/info.plist
+++ b/GeoIP2/info.plist
@@ -243,7 +243,7 @@ if [ -f ${GL2CITY}.tar.gz -a "$SHA256" == "$(shasum -a 256 ${GL2CITY}.tar.gz | a
     exit 0
 fi
 
-wget "$GeoURL?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz" -O ${GL2CITY}.tmp.tar.gz
+curl -s "$GeoURL?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz" > ${GL2CITY}.tmp.tar.gz
 
 SHA256=$(shasum -a 256 ${GL2CITY}.tar.gz | awk '{print $1}')
 

--- a/GeoIP2/info.plist
+++ b/GeoIP2/info.plist
@@ -229,26 +229,34 @@
 				<key>script</key>
 				<string>#!/bin/bash
 
-GeoURL="http://geolite.maxmind.com/download/geoip/database/"
+#!/bin/bash
+
+LicenseKey=YOUR_LICENSE_KEY
 GL2CITY="GeoLite2-City"
+GeoURL="https://download.maxmind.com/app/geoip_download"
+
 
 cd mmdb
 
-MD5=$(curl -s $GeoURL/${GL2CITY}.md5)
+SHA256=$(curl -s "${GeoURL}?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz.sha256" | awk '{print $1}')
 
-if [ -f ${GL2CITY}.mmdb -a "$MD5" == "$(md5 -q ${GL2CITY}.mmdb)" ] ; then
+if [ -f ${GL2CITY}.tar.gz -a "$SHA256" == "$(sha256sum ${GL2CITY}.tar.gz | awk '{print $1}')" ] ; then
     echo "データベースは最新でした"
     exit 0
 fi
 
+wget "$GeoURL?edition_id=${GL2CITY}&license_key=${LicenseKey}&suffix=tar.gz" -O ${GL2CITY}.tmp.tar.gz
 
-MD5=$(curl -s $GeoURL/${GL2CITY}.mmdb.gz|gunzip|tee ${GL2CITY}.mmdb.tmp|md5 -q)
+SHA256=$(sha256sum ${GL2CITY}.tar.gz | awk '{print $1}')
 
-if [ "$MD5" == "$(md5 -q ${GL2CITY}.mmdb.tmp)" ] ; then
-    mv ${GL2CITY}.mmdb.tmp ${GL2CITY}.mmdb
+if [ "$SHA256" == "$(sha256sum ${GL2CITY}.tmp.tar.gz | awk '{print $1}')" ] ; then
+    cp -p ${GL2CITY}.tmp.tar.gz ${GL2CITY}.tar.gz
+    tar zxf ${GL2CITY}.tar.gz
+    mv GeoLite2-City_*/${GL2CITY}.mmdb ${GL2CITY}.mmdb
+    rm -rf GeoLite2-City_*
     echo "データベースを更新しました"
 else
-    rm -f ${GL2CITY}.mmdb.tmp
+    rm -f ${GL2CITY}.tmp.tar.gz
     echo "ダウンロードに失敗しました"
     exit 2
 fi


### PR DESCRIPTION
GeoLite2-City のデータベースの更新方法が変わったので、以下の通り変更する。

- ライセンスを入力してもらうようにする。
- DLのURLを変更する。
- READMEを更新する